### PR TITLE
Replace batch norms and add dropout

### DIFF
--- a/paco/diffusion_utils.py
+++ b/paco/diffusion_utils.py
@@ -9,6 +9,7 @@ from .transformer_utils import (
     DeformableLocalAttention,
     knn_point,
 )
+from utils.norms import LayerNorm1d
 
 
 class CrossScaleAttention(nn.Module):
@@ -77,6 +78,10 @@ class NoiseScheduler:
     def sample_timesteps(self, batch_size, device):
         """随机采样时间步"""
         return torch.randint(0, self.num_timesteps, (batch_size,), device=device)
+
+    def ddim_timesteps(self, batch_size, device):
+        """确定性 DDIM 采样时间步"""
+        return torch.linspace(0, self.num_timesteps - 1, steps=batch_size, device=device).long()
     
     def get_snr_weights(self, timesteps, use_sqrt=True, detach_weights=True):
         """计算SNR权重用于损失函数
@@ -149,7 +154,7 @@ class MultiScaleTokenExtractor(nn.Module):
         self.scale_extractors = nn.ModuleList([
             nn.Sequential(
                 nn.Conv1d(embed_dim, embed_dim, kernel_size=scale, stride=scale, padding=0),
-                nn.BatchNorm1d(embed_dim),
+                LayerNorm1d(embed_dim),
                 nn.GELU(),
                 nn.Conv1d(embed_dim, embed_dim, 1)
             ) for scale in scales
@@ -312,7 +317,7 @@ class TwoStageDiffusionModule(nn.Module):
             if training:
                 timesteps = self.noise_scheduler.sample_timesteps(B, x.device)
             else:
-                timesteps = torch.zeros(B, dtype=torch.long, device=x.device)
+                timesteps = self.noise_scheduler.ddim_timesteps(B, x.device)
         
         # 时间步嵌入
         time_emb = self.time_embedding(timesteps)

--- a/paco/paco/diffusion_utils.py
+++ b/paco/paco/diffusion_utils.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import numpy as np
 from typing import Optional, Tuple
+from utils.norms import LayerNorm1d
 
 
 class NoiseScheduler:
@@ -52,6 +53,10 @@ class NoiseScheduler:
     def sample_timesteps(self, batch_size, device):
         """随机采样时间步"""
         return torch.randint(0, self.num_timesteps, (batch_size,), device=device)
+
+    def ddim_timesteps(self, batch_size, device):
+        """确定性 DDIM 采样时间步"""
+        return torch.linspace(0, self.num_timesteps - 1, steps=batch_size, device=device).long()
     
     def get_snr_weights(self, timesteps, use_sqrt=True, detach_weights=True):
         """计算SNR权重用于损失函数
@@ -124,7 +129,7 @@ class MultiScaleTokenExtractor(nn.Module):
         self.scale_extractors = nn.ModuleList([
             nn.Sequential(
                 nn.Conv1d(embed_dim, embed_dim, kernel_size=scale, stride=scale, padding=0),
-                nn.BatchNorm1d(embed_dim),
+                LayerNorm1d(embed_dim),
                 nn.GELU(),
                 nn.Conv1d(embed_dim, embed_dim, 1)
             ) for scale in scales
@@ -282,7 +287,7 @@ class TwoStageDiffusionModule(nn.Module):
             if training:
                 timesteps = self.noise_scheduler.sample_timesteps(B, x.device)
             else:
-                timesteps = torch.zeros(B, dtype=torch.long, device=x.device)
+                timesteps = self.noise_scheduler.ddim_timesteps(B, x.device)
         
         # 时间步嵌入
         time_emb = self.time_embedding(timesteps)

--- a/paco/paco/paco_pipeline.py
+++ b/paco/paco/paco_pipeline.py
@@ -13,6 +13,7 @@ from .transformer_utils import (
     ImprovedDeformableLocalGraphAttention, CrossAttention,
     knn_point, index_points
 )
+from utils.norms import LayerNorm1d
 
 from .diffusion_utils import (
     TwoStageDiffusionModule, MultiScaleTokenExtractor, NoiseScheduler
@@ -767,13 +768,13 @@ class Encoder(nn.Module):
         self.encoder_channel = encoder_channel
         self.first_conv = nn.Sequential(
             nn.Conv1d(3, 128, 1),
-            nn.BatchNorm1d(128),
+            LayerNorm1d(128),
             nn.ReLU(inplace=True),
             nn.Conv1d(128, 256, 1)
         )
         self.second_conv = nn.Sequential(
             nn.Conv1d(512, 512, 1),
-            nn.BatchNorm1d(512),
+            LayerNorm1d(512),
             nn.ReLU(inplace=True),
             nn.Conv1d(512, self.encoder_channel, 1)
         )
@@ -876,20 +877,20 @@ class Fold(nn.Module):
 
         self.folding1 = nn.Sequential(
             nn.Conv1d(in_channel + 2, hidden_dim, 1),
-            nn.BatchNorm1d(hidden_dim),
+            LayerNorm1d(hidden_dim),
             nn.ReLU(inplace=True),
             nn.Conv1d(hidden_dim, hidden_dim // 2, 1),
-            nn.BatchNorm1d(hidden_dim // 2),
+            LayerNorm1d(hidden_dim // 2),
             nn.ReLU(inplace=True),
             nn.Conv1d(hidden_dim // 2, self.freedom, 1)
         )
 
         self.folding2 = nn.Sequential(
             nn.Conv1d(in_channel + self.freedom, hidden_dim, 1),
-            nn.BatchNorm1d(hidden_dim),
+            LayerNorm1d(hidden_dim),
             nn.ReLU(inplace=True),
             nn.Conv1d(hidden_dim, hidden_dim // 2, 1),
-            nn.BatchNorm1d(hidden_dim // 2),
+            LayerNorm1d(hidden_dim // 2),
             nn.ReLU(inplace=True),
             nn.Conv1d(hidden_dim // 2, self.freedom, 1)
         )
@@ -970,52 +971,70 @@ class PCTransformer(nn.Module):
             self.grouper = DGCNN_Grouper(k=self.group_k)
             self.plane_mlp = nn.Sequential(
                 nn.Linear(encoder.embed_dim * 2, encoder.embed_dim),
-                nn.GELU()
+                nn.GELU(),
+                nn.Dropout(0.25)
             )
         else:
             self.grouper = SimpleEncoder(k=self.group_k, num_planes=self.num_planes)
         self.pos_embed = nn.Sequential(
             nn.Linear(in_chans, 128),
             nn.GELU(),
-            nn.Linear(128, encoder.embed_dim)
+            nn.Dropout(0.25),
+            nn.Linear(128, encoder.embed_dim),
+            nn.Dropout(0.25)
         )
         self.plane_embed = nn.Sequential(
             nn.Linear(3, 128),
             nn.GELU(),
-            nn.Linear(128, encoder.embed_dim)
+            nn.Dropout(0.25),
+            nn.Linear(128, encoder.embed_dim),
+            nn.Dropout(0.25)
         )
         self.input_proj = nn.Sequential(
             nn.Linear(self.grouper.num_features, 512),
             nn.GELU(),
-            nn.Linear(512, encoder.embed_dim)
+            nn.Dropout(0.25),
+            nn.Linear(512, encoder.embed_dim),
+            nn.Dropout(0.25)
         )
         self.encoder = PointTransformerEncoderEntry(encoder)
         self.increase_dim = nn.Sequential(
             nn.Linear(encoder.embed_dim, 1024),
             nn.GELU(),
-            nn.Linear(1024, global_feature_dim))
+            nn.Dropout(0.25),
+            nn.Linear(1024, global_feature_dim),
+            nn.Dropout(0.25))
         if self.query_type == 'dynamic':
             self.plane_pred_coarse = nn.Sequential(
                 nn.Linear(global_feature_dim, 1024),
                 nn.GELU(),
-                nn.Linear(1024, 3 * query_num))
+                nn.Dropout(0.25),
+                nn.Linear(1024, 3 * query_num),
+                nn.Dropout(0.25))
             self.mlp_query = nn.Sequential(
                 nn.Linear(global_feature_dim + 3, 1024),
                 nn.GELU(),
+                nn.Dropout(0.25),
                 nn.Linear(1024, 1024),
                 nn.GELU(),
-                nn.Linear(1024, decoder.embed_dim))
+                nn.Dropout(0.25),
+                nn.Linear(1024, decoder.embed_dim),
+                nn.Dropout(0.25))
             self.plane_pred = nn.Sequential(
                 nn.Linear(decoder.embed_dim, decoder.embed_dim // 2),
                 nn.GELU(),
-                nn.Linear(decoder.embed_dim // 2, 3)
+                nn.Dropout(0.25),
+                nn.Linear(decoder.embed_dim // 2, 3),
+                nn.Dropout(0.25)
             )
         else:
             self.mlp_query = nn.Embedding(query_num, decoder.embed_dim)
             self.plane_pred = nn.Sequential(
                 nn.Linear(decoder.embed_dim, decoder.embed_dim // 2),
                 nn.GELU(),
-                nn.Linear(decoder.embed_dim // 2, 3)
+                nn.Dropout(0.25),
+                nn.Linear(decoder.embed_dim // 2, 3),
+                nn.Dropout(0.25)
             )
         # assert decoder.embed_dim == encoder.embed_dim
         if decoder.embed_dim == encoder.embed_dim:
@@ -1024,13 +1043,17 @@ class PCTransformer(nn.Module):
             self.mem_link = nn.Linear(encoder.embed_dim, decoder.embed_dim)
         self.decoder = PointTransformerDecoderEntry(decoder)
         if self.query_ranking:
-            self.plane_mlp2 = nn.Sequential(nn.Linear(encoder.embed_dim, encoder.embed_dim),
-                                            nn.GELU())
+            self.plane_mlp2 = nn.Sequential(
+                nn.Linear(encoder.embed_dim, encoder.embed_dim),
+                nn.GELU(),
+                nn.Dropout(0.25))
             self.query_ranking = nn.Sequential(
                 nn.Linear(decoder.embed_dim, 256),
                 nn.GELU(),
+                nn.Dropout(0.25),
                 nn.Linear(256, 256),
                 nn.GELU(),
+                nn.Dropout(0.25),
                 nn.Linear(256, 1),
                 nn.Sigmoid()
             )
@@ -1194,12 +1217,15 @@ class EnhancedPCTransformer(nn.Module):
         if self.query_ranking:
             self.plane_mlp2 = nn.Sequential(
                 nn.Linear(encoder.embed_dim, encoder.embed_dim),
-                nn.GELU())
+                nn.GELU(),
+                nn.Dropout(0.25))
             self.query_ranking = nn.Sequential(
                 nn.Linear(decoder.embed_dim, 256),
                 nn.GELU(),
+                nn.Dropout(0.25),
                 nn.Linear(256, 256),
                 nn.GELU(),
+                nn.Dropout(0.25),
                 nn.Linear(256, 1),
                 nn.Sigmoid()
             )
@@ -1330,7 +1356,7 @@ class PaCoDiT(nn.Module):
 
         self.increase_dim = nn.Sequential(
             nn.Conv1d(self.trans_dim, 1024, 1),
-            nn.BatchNorm1d(1024),
+            LayerNorm1d(1024),
             nn.LeakyReLU(negative_slope=0.2),
             nn.Conv1d(1024, 1024, 1)
         )
@@ -1340,10 +1366,10 @@ class PaCoDiT(nn.Module):
 
         self.rebuild_map = nn.Sequential(
             nn.Conv1d(self.trans_dim, hidden_dim, 1),
-            nn.BatchNorm1d(hidden_dim),
+            LayerNorm1d(hidden_dim),
             nn.ReLU(inplace=True),
             nn.Conv1d(hidden_dim, hidden_dim // 2, 1),
-            nn.BatchNorm1d(hidden_dim // 2),
+            LayerNorm1d(hidden_dim // 2),
             nn.ReLU(inplace=True),
         )
         self.classifier = nn.Linear(hidden_dim // 2, 2)

--- a/paco/paco/transformer_utils.py
+++ b/paco/paco/transformer_utils.py
@@ -70,8 +70,8 @@ class MLP(nn.Module):
     A simple MLP with configurable hidden dimension and dropout.
     """
     
-    def __init__(self, in_features: int, hidden_features: int = None, 
-                out_features: int = None, act_layer=nn.GELU, drop: float = 0.):
+    def __init__(self, in_features: int, hidden_features: int = None,
+                out_features: int = None, act_layer=nn.GELU, drop: float = 0.25):
         """Initialize MLP.
         
         Args:

--- a/paco/paco_pipeline.py
+++ b/paco/paco_pipeline.py
@@ -13,6 +13,7 @@ from .transformer_utils import (
     ImprovedDeformableLocalGraphAttention, CrossAttention,
     knn_point, index_points
 )
+from utils.norms import LayerNorm1d
 
 from .diffusion_utils import (
     TwoStageDiffusionModule, MultiScaleTokenExtractor, NoiseScheduler
@@ -767,13 +768,13 @@ class Encoder(nn.Module):
         self.encoder_channel = encoder_channel
         self.first_conv = nn.Sequential(
             nn.Conv1d(3, 128, 1),
-            nn.BatchNorm1d(128),
+            LayerNorm1d(128),
             nn.ReLU(inplace=True),
             nn.Conv1d(128, 256, 1)
         )
         self.second_conv = nn.Sequential(
             nn.Conv1d(512, 512, 1),
-            nn.BatchNorm1d(512),
+            LayerNorm1d(512),
             nn.ReLU(inplace=True),
             nn.Conv1d(512, self.encoder_channel, 1)
         )
@@ -876,20 +877,20 @@ class Fold(nn.Module):
 
         self.folding1 = nn.Sequential(
             nn.Conv1d(in_channel + 2, hidden_dim, 1),
-            nn.BatchNorm1d(hidden_dim),
+            LayerNorm1d(hidden_dim),
             nn.ReLU(inplace=True),
             nn.Conv1d(hidden_dim, hidden_dim // 2, 1),
-            nn.BatchNorm1d(hidden_dim // 2),
+            LayerNorm1d(hidden_dim // 2),
             nn.ReLU(inplace=True),
             nn.Conv1d(hidden_dim // 2, self.freedom, 1)
         )
 
         self.folding2 = nn.Sequential(
             nn.Conv1d(in_channel + self.freedom, hidden_dim, 1),
-            nn.BatchNorm1d(hidden_dim),
+            LayerNorm1d(hidden_dim),
             nn.ReLU(inplace=True),
             nn.Conv1d(hidden_dim, hidden_dim // 2, 1),
-            nn.BatchNorm1d(hidden_dim // 2),
+            LayerNorm1d(hidden_dim // 2),
             nn.ReLU(inplace=True),
             nn.Conv1d(hidden_dim // 2, self.freedom, 1)
         )
@@ -970,52 +971,70 @@ class PCTransformer(nn.Module):
             self.grouper = DGCNN_Grouper(k=self.group_k)
             self.plane_mlp = nn.Sequential(
                 nn.Linear(encoder.embed_dim * 2, encoder.embed_dim),
-                nn.GELU()
+                nn.GELU(),
+                nn.Dropout(0.25)
             )
         else:
             self.grouper = SimpleEncoder(k=self.group_k, num_planes=self.num_planes)
         self.pos_embed = nn.Sequential(
             nn.Linear(in_chans, 128),
             nn.GELU(),
-            nn.Linear(128, encoder.embed_dim)
+            nn.Dropout(0.25),
+            nn.Linear(128, encoder.embed_dim),
+            nn.Dropout(0.25)
         )
         self.plane_embed = nn.Sequential(
             nn.Linear(3, 128),
             nn.GELU(),
-            nn.Linear(128, encoder.embed_dim)
+            nn.Dropout(0.25),
+            nn.Linear(128, encoder.embed_dim),
+            nn.Dropout(0.25)
         )
         self.input_proj = nn.Sequential(
             nn.Linear(self.grouper.num_features, 512),
             nn.GELU(),
-            nn.Linear(512, encoder.embed_dim)
+            nn.Dropout(0.25),
+            nn.Linear(512, encoder.embed_dim),
+            nn.Dropout(0.25)
         )
         self.encoder = PointTransformerEncoderEntry(encoder)
         self.increase_dim = nn.Sequential(
             nn.Linear(encoder.embed_dim, 1024),
             nn.GELU(),
-            nn.Linear(1024, global_feature_dim))
+            nn.Dropout(0.25),
+            nn.Linear(1024, global_feature_dim),
+            nn.Dropout(0.25))
         if self.query_type == 'dynamic':
             self.plane_pred_coarse = nn.Sequential(
                 nn.Linear(global_feature_dim, 1024),
                 nn.GELU(),
-                nn.Linear(1024, 3 * query_num))
+                nn.Dropout(0.25),
+                nn.Linear(1024, 3 * query_num),
+                nn.Dropout(0.25))
             self.mlp_query = nn.Sequential(
                 nn.Linear(global_feature_dim + 3, 1024),
                 nn.GELU(),
+                nn.Dropout(0.25),
                 nn.Linear(1024, 1024),
                 nn.GELU(),
-                nn.Linear(1024, decoder.embed_dim))
+                nn.Dropout(0.25),
+                nn.Linear(1024, decoder.embed_dim),
+                nn.Dropout(0.25))
             self.plane_pred = nn.Sequential(
                 nn.Linear(decoder.embed_dim, decoder.embed_dim // 2),
                 nn.GELU(),
-                nn.Linear(decoder.embed_dim // 2, 3)
+                nn.Dropout(0.25),
+                nn.Linear(decoder.embed_dim // 2, 3),
+                nn.Dropout(0.25)
             )
         else:
             self.mlp_query = nn.Embedding(query_num, decoder.embed_dim)
             self.plane_pred = nn.Sequential(
                 nn.Linear(decoder.embed_dim, decoder.embed_dim // 2),
                 nn.GELU(),
-                nn.Linear(decoder.embed_dim // 2, 3)
+                nn.Dropout(0.25),
+                nn.Linear(decoder.embed_dim // 2, 3),
+                nn.Dropout(0.25)
             )
         # assert decoder.embed_dim == encoder.embed_dim
         if decoder.embed_dim == encoder.embed_dim:
@@ -1024,13 +1043,17 @@ class PCTransformer(nn.Module):
             self.mem_link = nn.Linear(encoder.embed_dim, decoder.embed_dim)
         self.decoder = PointTransformerDecoderEntry(decoder)
         if self.query_ranking:
-            self.plane_mlp2 = nn.Sequential(nn.Linear(encoder.embed_dim, encoder.embed_dim),
-                                            nn.GELU())
+            self.plane_mlp2 = nn.Sequential(
+                nn.Linear(encoder.embed_dim, encoder.embed_dim),
+                nn.GELU(),
+                nn.Dropout(0.25))
             self.query_ranking = nn.Sequential(
                 nn.Linear(decoder.embed_dim, 256),
                 nn.GELU(),
+                nn.Dropout(0.25),
                 nn.Linear(256, 256),
                 nn.GELU(),
+                nn.Dropout(0.25),
                 nn.Linear(256, 1),
                 nn.Sigmoid()
             )
@@ -1149,30 +1172,41 @@ class EnhancedPCTransformer(nn.Module):
         self.increase_dim = nn.Sequential(
             nn.Linear(encoder.embed_dim, 1024),
             nn.GELU(),
-            nn.Linear(1024, global_feature_dim))
+            nn.Dropout(0.25),
+            nn.Linear(1024, global_feature_dim),
+            nn.Dropout(0.25))
             
         if self.query_type == 'dynamic':
             self.plane_pred_coarse = nn.Sequential(
                 nn.Linear(global_feature_dim, 1024),
                 nn.GELU(),
-                nn.Linear(1024, 3 * query_num))
+                nn.Dropout(0.25),
+                nn.Linear(1024, 3 * query_num),
+                nn.Dropout(0.25))
             self.mlp_query = nn.Sequential(
                 nn.Linear(global_feature_dim + 3, 1024),
                 nn.GELU(),
+                nn.Dropout(0.25),
                 nn.Linear(1024, 1024),
                 nn.GELU(),
-                nn.Linear(1024, decoder.embed_dim))
+                nn.Dropout(0.25),
+                nn.Linear(1024, decoder.embed_dim),
+                nn.Dropout(0.25))
             self.plane_pred = nn.Sequential(
                 nn.Linear(decoder.embed_dim, decoder.embed_dim // 2),
                 nn.GELU(),
-                nn.Linear(decoder.embed_dim // 2, 3)
+                nn.Dropout(0.25),
+                nn.Linear(decoder.embed_dim // 2, 3),
+                nn.Dropout(0.25)
             )
         else:
             self.mlp_query = nn.Embedding(query_num, decoder.embed_dim)
             self.plane_pred = nn.Sequential(
                 nn.Linear(decoder.embed_dim, decoder.embed_dim // 2),
                 nn.GELU(),
-                nn.Linear(decoder.embed_dim // 2, 3)
+                nn.Dropout(0.25),
+                nn.Linear(decoder.embed_dim // 2, 3),
+                nn.Dropout(0.25)
             )
             
         # 内存链接
@@ -1194,12 +1228,15 @@ class EnhancedPCTransformer(nn.Module):
         if self.query_ranking:
             self.plane_mlp2 = nn.Sequential(
                 nn.Linear(encoder.embed_dim, encoder.embed_dim),
-                nn.GELU())
+                nn.GELU(),
+                nn.Dropout(0.25))
             self.query_ranking = nn.Sequential(
                 nn.Linear(decoder.embed_dim, 256),
                 nn.GELU(),
+                nn.Dropout(0.25),
                 nn.Linear(256, 256),
                 nn.GELU(),
+                nn.Dropout(0.25),
                 nn.Linear(256, 1),
                 nn.Sigmoid()
             )
@@ -1331,7 +1368,7 @@ class PaCoDiT(nn.Module):
 
         self.increase_dim = nn.Sequential(
             nn.Conv1d(self.trans_dim, 1024, 1),
-            nn.BatchNorm1d(1024),
+            LayerNorm1d(1024),
             nn.LeakyReLU(negative_slope=0.2),
             nn.Conv1d(1024, 1024, 1)
         )
@@ -1341,10 +1378,10 @@ class PaCoDiT(nn.Module):
 
         self.rebuild_map = nn.Sequential(
             nn.Conv1d(self.trans_dim, hidden_dim, 1),
-            nn.BatchNorm1d(hidden_dim),
+            LayerNorm1d(hidden_dim),
             nn.ReLU(inplace=True),
             nn.Conv1d(hidden_dim, hidden_dim // 2, 1),
-            nn.BatchNorm1d(hidden_dim // 2),
+            LayerNorm1d(hidden_dim // 2),
             nn.ReLU(inplace=True),
         )
         self.classifier = nn.Linear(hidden_dim // 2, 2)

--- a/paco/transformer_utils.py
+++ b/paco/transformer_utils.py
@@ -70,8 +70,8 @@ class MLP(nn.Module):
     A simple MLP with configurable hidden dimension and dropout.
     """
     
-    def __init__(self, in_features: int, hidden_features: int = None, 
-                out_features: int = None, act_layer=nn.GELU, drop: float = 0.):
+    def __init__(self, in_features: int, hidden_features: int = None,
+                out_features: int = None, act_layer=nn.GELU, drop: float = 0.25):
         """Initialize MLP.
         
         Args:

--- a/paco/utils/norms.py
+++ b/paco/utils/norms.py
@@ -1,0 +1,14 @@
+import torch
+from torch import nn
+
+class LayerNorm1d(nn.Module):
+    """LayerNorm for 1D Conv features of shape (B, C, N)."""
+    def __init__(self, num_features: int):
+        super().__init__()
+        self.norm = nn.LayerNorm(num_features)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (B, C, N)
+        x = x.transpose(1, 2)
+        x = self.norm(x)
+        return x.transpose(1, 2)


### PR DESCRIPTION
## Summary
- add helper `LayerNorm1d` for conv outputs
- replace all `BatchNorm1d` with `LayerNorm1d`
- insert dropout layers around fully-connected layers
- increase default MLP dropout
- use deterministic DDIM sampling when evaluating

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68736b0880888331ab361252d3b33d96