### PR TITLE
Add learnable query-based plane grouper

### DIFF
--- a/conf/model/paco.yaml
+++ b/conf/model/paco.yaml
@@ -6,7 +6,7 @@ num_centers: [128, 128]
 group_k: 32
 global_feature_dim: 1024
 
-encoder_type: graph
+encoder_type: learnable
 decoder_type: fc
 query_type: dynamic
 query_ranking: true

--- a/paco/conf/model/paco.yaml
+++ b/paco/conf/model/paco.yaml
@@ -6,7 +6,7 @@ num_centers: [128, 128]
 group_k: 32
 global_feature_dim: 1024
 
-encoder_type: graph
+encoder_type: learnable
 decoder_type: fc
 query_type: dynamic
 query_ranking: true

--- a/paco/learnable_grouper.py
+++ b/paco/learnable_grouper.py
@@ -1,0 +1,99 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class _DecoderLayer(nn.Module):
+    """A simplified transformer decoder layer for plane queries."""
+
+    def __init__(self, embed_dim: int, num_heads: int):
+        super().__init__()
+        self.cross_attn = nn.MultiheadAttention(
+            embed_dim, num_heads, batch_first=True
+        )
+        self.ffn = nn.Sequential(
+            nn.Linear(embed_dim, embed_dim * 2),
+            nn.ReLU(inplace=True),
+            nn.Linear(embed_dim * 2, embed_dim),
+        )
+        self.norm1 = nn.LayerNorm(embed_dim)
+        self.norm2 = nn.LayerNorm(embed_dim)
+
+    def forward(self, queries: torch.Tensor, points: torch.Tensor):
+        attn_out, attn = self.cross_attn(
+            queries, points, points, need_weights=True
+        )
+        queries = self.norm1(queries + attn_out)
+        ffn_out = self.ffn(queries)
+        queries = self.norm2(queries + ffn_out)
+        return queries, attn
+
+
+class LearnableQueryGrouper(nn.Module):
+    """Group points to plane proxies with learnable queries.
+
+    The module maintains a fixed number of learnable plane queries and
+    predicts soft assignments of input points to these queries through a
+    stack of cross‑attention layers.  Each query produces a plane feature,
+    aggregated coordinates and normals.
+    """
+
+    def __init__(
+        self,
+        num_queries: int,
+        embed_dim: int = 128,
+        num_heads: int = 4,
+        num_layers: int = 2,
+        temperature: float = 1.0,
+    ):
+        super().__init__()
+        self.num_queries = num_queries
+        self.num_features = embed_dim
+        self.temperature = temperature
+
+        self.point_proj = nn.Linear(6, embed_dim)
+        self.query_embed = nn.Parameter(torch.randn(num_queries, embed_dim))
+        self.layers = nn.ModuleList(
+            [_DecoderLayer(embed_dim, num_heads) for _ in range(num_layers)]
+        )
+        self.confidence_head = nn.Linear(embed_dim, 1)
+
+    def forward(self, x: torch.Tensor, num=None):
+        """Forward pass.
+
+        Args:
+            x: input tensor of shape (B, N, 7) containing xyz, normal and
+               placeholder plane ids.
+            num: ignored, kept for interface compatibility.
+
+        Returns:
+            coor:   (B, Q, 3) aggregated coordinates per query.
+            feat:   (B, Q, C) plane features.
+            normal: (B, Q, 3) aggregated normals.
+            plane_idx: (B, Q, 1) query indices.
+            assign: (B, Q, N) soft point assignments.
+            confidence: (B, Q) existence probabilities for queries.
+        """
+        b, n, _ = x.shape
+        coor = x[:, :, :3]
+        normal = x[:, :, 3:6]
+
+        point_feat = self.point_proj(torch.cat([coor, normal], dim=-1))
+
+        queries = self.query_embed.unsqueeze(0).expand(b, -1, -1)
+        attn = None
+        for layer in self.layers:
+            queries, attn = layer(queries, point_feat)
+
+        assign = F.softmax(attn / self.temperature, dim=1)  # (B, Q, N)
+        feat = torch.einsum("bqn,bnd->bqd", assign, point_feat)
+        agg_coor = torch.einsum("bqn,bnd->bqd", assign, coor)
+        agg_normal = torch.einsum("bqn,bnd->bqd", assign, normal)
+        plane_idx = (
+            torch.arange(self.num_queries, device=x.device)
+            .view(1, self.num_queries, 1)
+            .expand(b, -1, -1)
+        )
+        confidence = torch.sigmoid(self.confidence_head(queries)).squeeze(-1)
+        return agg_coor, feat, agg_normal, plane_idx, assign, confidence
+

--- a/paco/paco/learnable_grouper.py
+++ b/paco/paco/learnable_grouper.py
@@ -1,0 +1,78 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class _DecoderLayer(nn.Module):
+    """A simplified transformer decoder layer for plane queries."""
+
+    def __init__(self, embed_dim: int, num_heads: int):
+        super().__init__()
+        self.cross_attn = nn.MultiheadAttention(
+            embed_dim, num_heads, batch_first=True
+        )
+        self.ffn = nn.Sequential(
+            nn.Linear(embed_dim, embed_dim * 2),
+            nn.ReLU(inplace=True),
+            nn.Linear(embed_dim * 2, embed_dim),
+        )
+        self.norm1 = nn.LayerNorm(embed_dim)
+        self.norm2 = nn.LayerNorm(embed_dim)
+
+    def forward(self, queries: torch.Tensor, points: torch.Tensor):
+        attn_out, attn = self.cross_attn(
+            queries, points, points, need_weights=True
+        )
+        queries = self.norm1(queries + attn_out)
+        ffn_out = self.ffn(queries)
+        queries = self.norm2(queries + ffn_out)
+        return queries, attn
+
+
+class LearnableQueryGrouper(nn.Module):
+    """Group points to plane proxies with learnable queries."""
+
+    def __init__(
+        self,
+        num_queries: int,
+        embed_dim: int = 128,
+        num_heads: int = 4,
+        num_layers: int = 2,
+        temperature: float = 1.0,
+    ):
+        super().__init__()
+        self.num_queries = num_queries
+        self.num_features = embed_dim
+        self.temperature = temperature
+
+        self.point_proj = nn.Linear(6, embed_dim)
+        self.query_embed = nn.Parameter(torch.randn(num_queries, embed_dim))
+        self.layers = nn.ModuleList(
+            [_DecoderLayer(embed_dim, num_heads) for _ in range(num_layers)]
+        )
+        self.confidence_head = nn.Linear(embed_dim, 1)
+
+    def forward(self, x: torch.Tensor, num=None):
+        b, n, _ = x.shape
+        coor = x[:, :, :3]
+        normal = x[:, :, 3:6]
+
+        point_feat = self.point_proj(torch.cat([coor, normal], dim=-1))
+
+        queries = self.query_embed.unsqueeze(0).expand(b, -1, -1)
+        attn = None
+        for layer in self.layers:
+            queries, attn = layer(queries, point_feat)
+
+        assign = F.softmax(attn / self.temperature, dim=1)
+        feat = torch.einsum("bqn,bnd->bqd", assign, point_feat)
+        agg_coor = torch.einsum("bqn,bnd->bqd", assign, coor)
+        agg_normal = torch.einsum("bqn,bnd->bqd", assign, normal)
+        plane_idx = (
+            torch.arange(self.num_queries, device=x.device)
+            .view(1, self.num_queries, 1)
+            .expand(b, -1, -1)
+        )
+        confidence = torch.sigmoid(self.confidence_head(queries)).squeeze(-1)
+        return agg_coor, feat, agg_normal, plane_idx, assign, confidence
+

--- a/paco/paco/paco_pipeline.py
+++ b/paco/paco/paco_pipeline.py
@@ -13,6 +13,7 @@ from .transformer_utils import (
     ImprovedDeformableLocalGraphAttention, CrossAttention,
     knn_point, index_points
 )
+from .learnable_grouper import LearnableQueryGrouper
 
 from .diffusion_utils import (
     TwoStageDiffusionModule, MultiScaleTokenExtractor, NoiseScheduler
@@ -972,8 +973,18 @@ class PCTransformer(nn.Module):
                 nn.Linear(encoder.embed_dim * 2, encoder.embed_dim),
                 nn.GELU()
             )
+        elif self.encoder_type == 'learnable':
+            self.grouper = LearnableQueryGrouper(num_queries=self.num_planes)
+            self.plane_mlp = nn.Sequential(
+                nn.Linear(encoder.embed_dim * 2, encoder.embed_dim),
+                nn.GELU()
+            )
         else:
             self.grouper = SimpleEncoder(k=self.group_k, num_planes=self.num_planes)
+            self.plane_mlp = nn.Sequential(
+                nn.Linear(encoder.embed_dim * 2, encoder.embed_dim),
+                nn.GELU()
+            )
         self.pos_embed = nn.Sequential(
             nn.Linear(in_chans, 128),
             nn.GELU(),
@@ -1047,7 +1058,16 @@ class PCTransformer(nn.Module):
 
     def forward(self, xyz):
         bs, _, _ = xyz.size()
-        coor, f, normal, batch = self.grouper(xyz, self.num_centers)
+        grouper_out = self.grouper(xyz, self.num_centers)
+        coor, f, normal, batch = grouper_out[:4]
+        if len(grouper_out) > 4:
+            self.assignments = grouper_out[4]
+        else:
+            self.assignments = None
+        if len(grouper_out) > 5:
+            self.query_confidence = grouper_out[5]
+        else:
+            self.query_confidence = None
         pe = self.pos_embed(coor)
         x = self.input_proj(f)
         x = self.encoder(x + pe, coor)
@@ -1216,7 +1236,16 @@ class EnhancedPCTransformer(nn.Module):
 
     def forward(self, xyz, timesteps=None):
         bs, _, _ = xyz.size()
-        coor, f, normal, batch = self.grouper(xyz, self.num_centers)
+        grouper_out = self.grouper(xyz, self.num_centers)
+        coor, f, normal, batch = grouper_out[:4]
+        if len(grouper_out) > 4:
+            self.assignments = grouper_out[4]
+        else:
+            self.assignments = None
+        if len(grouper_out) > 5:
+            self.query_confidence = grouper_out[5]
+        else:
+            self.query_confidence = None
         pe = self.pos_embed(coor)
         x = self.input_proj(f)
         

--- a/paco/paco_pipeline.py
+++ b/paco/paco_pipeline.py
@@ -13,6 +13,7 @@ from .transformer_utils import (
     ImprovedDeformableLocalGraphAttention, CrossAttention,
     knn_point, index_points
 )
+from .learnable_grouper import LearnableQueryGrouper
 
 class PointLevelProcessor(nn.Module):
     """
@@ -1206,8 +1207,19 @@ class PCTransformer(nn.Module):
                 nn.Linear(encoder.embed_dim * 2, encoder.embed_dim),
                 nn.GELU()
             )
+        elif self.encoder_type == 'learnable':
+            self.grouper = LearnableQueryGrouper(num_queries=self.num_planes)
+            self.plane_mlp = nn.Sequential(
+                nn.Linear(encoder.embed_dim * 2, encoder.embed_dim),
+                nn.GELU()
+            )
         else:
             self.grouper = SimpleEncoder(k=self.group_k, num_planes=self.num_planes)
+            self.plane_mlp = nn.Sequential(
+                nn.Linear(encoder.embed_dim * 2, encoder.embed_dim),
+                nn.GELU()
+            )
+
         self.pos_embed = nn.Sequential(
             nn.Linear(in_chans, 128),
             nn.GELU(),
@@ -1294,7 +1306,16 @@ class PCTransformer(nn.Module):
 
     def forward(self, xyz):
         bs, _, _ = xyz.size()
-        coor, f, normal, batch = self.grouper(xyz, self.num_centers)
+        grouper_out = self.grouper(xyz, self.num_centers)
+        coor, f, normal, batch = grouper_out[:4]
+        if len(grouper_out) > 4:
+            self.assignments = grouper_out[4]
+        else:
+            self.assignments = None
+        if len(grouper_out) > 5:
+            self.query_confidence = grouper_out[5]
+        else:
+            self.query_confidence = None
         pe = self.pos_embed(coor)
         x = self.input_proj(f)
         x = self.encoder(x + pe, coor)


### PR DESCRIPTION
## Summary
- add LearnableQueryGrouper using transformer queries for plane grouping
- wire grouper into PCTransformer and configs

## Testing
- `python -m py_compile MPPC/paco/learnable_grouper.py MPPC/paco/paco_pipeline.py MPPC/paco/paco/learnable_grouper.py MPPC/paco/paco/paco_pipeline.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6b1efc08c8331826277ba2fffcdb9